### PR TITLE
feat: detect extraneous/missing imports/requires

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -179,6 +179,10 @@
     "import/no-webpack-loader-syntax": "error",
 
     "node/no-deprecated-api": "error",
+    "node/no-extraneous-import": "error",
+    "node/no-extraneous-require": "error",
+    "node/no-missing-import": "error",
+    "node/no-missing-require": "error",
     "node/process-exit-as-throw": "error",
 
     "promise/param-names": "error",


### PR DESCRIPTION
- extraneous: modules that are absent from `package.json`
- missing: modules that do not exist (necessary for local modules)

I have started testing this config in my projects, it seems to work fine, I did not see any major perf impact but we should pay attention to it.