### PR TITLE
update to eslint v4 and eslint-plugin-node v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "url": "https://github.com/feross/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
+    "eslint": "^4.12.1",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.0",
     "tape": "^4.6.3"
@@ -48,9 +48,9 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": ">=3.19.0",
+    "eslint": ">=4.12.1",
     "eslint-plugin-import": ">=2.2.0",
-    "eslint-plugin-node": ">=4.2.2",
+    "eslint-plugin-node": ">=5.2.1",
     "eslint-plugin-promise": ">=3.5.0",
     "eslint-plugin-standard": ">=3.0.0"
   },


### PR DESCRIPTION
 - eslint 4 rule updates that affect `standard`:
    - The `indent` rule is more strict.
    - The `padded-blocks` rule is more strict.
    - The `space-before-function-paren` rule is more strict.
    - The `no-multi-spaces` rule is more strict.
    - Minor improvements to `no-extra-parens`, `no-unexpected-multiline`, `no-regex-spaces`, and `space-unary-ops` 

 - eslint-plugin-node rule updates:
  - The `no-deprecated-api` rule updated to with node 8 support and better node 6 support.