### PR TITLE
Added no-bitwise rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -67,7 +67,7 @@
     "new-cap": ["error", { "newIsCap": true, "capIsNew": false }],
     "new-parens": "error",
     "no-array-constructor": "error",
-    "no-bitwise": ["error", { "int32Hint": true }]
+    "no-bitwise": ["error", { "int32Hint": true }],
     "no-caller": "error",
     "no-class-assign": "error",
     "no-compare-neg-zero": "error",

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -67,6 +67,7 @@
     "new-cap": ["error", { "newIsCap": true, "capIsNew": false }],
     "new-parens": "error",
     "no-array-constructor": "error",
+    "no-bitwise": ["error", { "int32Hint": true }]
     "no-caller": "error",
     "no-class-assign": "error",
     "no-compare-neg-zero": "error",


### PR DESCRIPTION
Added a rule to disallow bitwise operators, except for type casting. Reference: https://eslint.org/docs/rules/no-bitwise#int32hint

This closes [standard#1042](https://github.com/standard/standard/issues/1042)

In the above issue, I mentioned only allowing bitwise operators on numbers. This PR only adds the standard no-bitwise ("int32Hint": true) rule which doesn't allow for that use case. I'm not sure if that sort of type check is possible with a custom ES Lint rule, but if it is I can go ahead and implement that as well.