### PR TITLE
Add an exception so a linebreak should happen before the pipeline operator

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -159,7 +159,7 @@
     "no-with": "error",
     "object-property-newline": ["error", { "allowMultiplePropertiesPerLine": true }],
     "one-var": ["error", { "initialized": "never" }],
-    "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before" } }],
+    "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before", "|>": "before" } }],
     "padded-blocks": ["error", { "blocks": "never", "switches": "never", "classes": "never" }],
     "prefer-promise-reject-errors": "error",
     "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],


### PR DESCRIPTION
Babel 7 has support for the proposed pipeline operator. See 

- https://www.npmjs.com/package/@babel/plugin-proposal-pipeline-operator
- https://github.com/tc39/proposal-pipeline-operator

Right now, standard requires this linebreak to occur at the end of the line, which is an uncommon place for a pipeline operator compared to other languages implementing them (the previous link to the TC39 proposal links out to various examples of other languages), where it is very common to see this operator occurring at the start of a new line.

This PR adds an exception for the pipeline operator, next to the ternary operator exception already being part of standard. 