### PR TITLE
Update to eslint-plugin-node 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "eslint": "^5.0.0-alpha.2",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "tape": "^4.8.0"
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "eslint": ">=5.0.0-alpha.2",
     "eslint-plugin-import": ">=2.8.0",
-    "eslint-plugin-node": ">=5.2.1",
+    "eslint-plugin-node": ">=6.0.1",
     "eslint-plugin-promise": ">=3.6.0",
     "eslint-plugin-standard": ">=3.0.1"
   },


### PR DESCRIPTION
Release notes: https://github.com/mysticatea/eslint-plugin-node/releases/tag/v6.0.0

Would be good in preparation for version 12.0.0 of this module, which should be close now that ESLint 5.0.0 has been released