### PR TITLE
Add the object-curly-spacing rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -157,6 +157,7 @@
     "no-useless-return": "error",
     "no-whitespace-before-property": "error",
     "no-with": "error",
+    "object-curly-spacing": ["error", "always"],
     "object-property-newline": ["error", { "allowMultiplePropertiesPerLine": true }],
     "one-var": ["error", { "initialized": "never" }],
     "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before" } }],


### PR DESCRIPTION
Per discussion [here](https://github.com/standard/standard/issues/609#issuecomment-400826566) (https://github.com/standard/standard/issues/609#issuecomment-400826566) it seems like it's both time for this to happen, and that the community prefers `"always"`.

ping @feross @Flet @dcousens 