### PR TITLE
Remove redundant no-label-var rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -97,7 +97,7 @@
     "no-invalid-regexp": "error",
     "no-irregular-whitespace": "error",
     "no-iterator": "error",
-    "no-labels": "error",
+    "no-labels": ["error", { "allowLoop": false, "allowSwitch": false }],
     "no-lone-blocks": "error",
     "no-mixed-operators": ["error", {
       "groups": [

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -97,8 +97,7 @@
     "no-invalid-regexp": "error",
     "no-irregular-whitespace": "error",
     "no-iterator": "error",
-    "no-label-var": "error",
-    "no-labels": ["error", { "allowLoop": false, "allowSwitch": false }],
+    "no-labels": "error",
     "no-lone-blocks": "error",
     "no-mixed-operators": ["error", {
       "groups": [


### PR DESCRIPTION
no-labels bans all labels, so it's not necessary to enable no-label-var (which lints how labels are used). Additionally, our settings for no-labels are equivalent to the defaults.