### PR TITLE
Add rule "prefer-const"

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -162,6 +162,7 @@
     "one-var": ["error", { "initialized": "never" }],
     "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": ["error", { "blocks": "never", "switches": "never", "classes": "never" }],
+    "prefer-const": ["error"],
     "prefer-promise-reject-errors": "error",
     "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "rest-spread-spacing": ["error", "never"],


### PR DESCRIPTION
Ecosystem impact:

- [x] [`babel-tape-runner`](https://github.com/wavded/babel-tape-runner) (https://github.com/wavded/babel-tape-runner/pull/27)
- [x] [`merge2`](https://github.com/teambition/merge2) (https://github.com/teambition/merge2/pull/23)
- [x] [`magic-virtual-element`](https://github.com/dekujs/magic-virtual-element) (https://github.com/dekujs/magic-virtual-element/pull/7)
- [x] [`echint`](https://github.com/ahmadnassri/echint) (https://github.com/ahmadnassri/echint/pull/106)
- [x] [`jsreport-core`](https://github.com/jsreport/jsreport-core) (https://github.com/jsreport/jsreport-core/pull/38)
- [x] [`jsreport-express`](https://github.com/jsreport/jsreport-express) (https://github.com/jsreport/jsreport-express/pull/11)
- [x] [`mkdirp-promise`](https://github.com/ahmadnassri/mkdirp-promise) (https://github.com/ahmadnassri/mkdirp-promise/pull/83)
- [x] [`har-validator`](https://github.com/ahmadnassri/har-validator) (https://github.com/ahmadnassri/har-validator/pull/111)
- [x] [`multihashes`](https://github.com/jbenet/js-multihash) (https://github.com/multiformats/js-multihash/pull/58)
- [x] [`thunk-redis`](https://github.com/thunks/thunk-redis) (https://github.com/thunks/thunk-redis/pull/24)
- [x] [`ipld`](https://github.com/diasdavid/js-ipld) (https://github.com/ipld/js-ipld-dag-cbor/pull/82)
- [x] [`fs-writefile-promise`](https://github.com/ahmadnassri/fs-writefile-promise) (https://github.com/ahmadnassri/node-fs-writefile-promise/pull/79)
- [x] [`html-validator`](https://github.com/zrrrzzt/html-validator) (https://github.com/zrrrzzt/html-validator/pull/92)
- [x] [`libp2p-tcp`](https://github.com/diasdavid/js-libp2p-tcp) (https://github.com/libp2p/js-libp2p-tcp/pull/99)
- [x] [`route-trie`](https://github.com/zensh/route-trie) (https://github.com/zensh/route-trie/pull/14)
- [x] [`respjs`](https://github.com/zensh/resp.js) (https://github.com/zensh/resp.js/pull/2)
- [x] [`hapi-swaggered`](https://github.com/z0mt3c/hapi-swaggered) (https://github.com/z0mt3c/hapi-swaggered/pull/174)
- [x] [`js-data-adapter-tests`](https://github.com/js-data/js-data-adapter-tests) (https://github.com/js-data/js-data-adapter-tests/pull/3)
- [x] [`stringify-clone`](https://github.com/ahmadnassri/stringify-clone) (https://github.com/ahmadnassri/stringify-clone/pull/59)
- [x] [`ipfs-repo`](https://github.com/ipfs/js-ipfs-repo) (https://github.com/ipfs/js-ipfs-repo/pull/178)
- [x] [`toa-token`](https://github.com/toajs/toa-token) (https://github.com/toajs/toa-token/pull/1)
- [x] [`make-concurrent`](https://github.com/fanatid/make-concurrent) (https://github.com/fanatid/make-concurrent/pull/2)
- [x] [`studynotes`](https://github.com/feross/studynotes) (https://github.com/feross/studynotes.org/pull/387)
- [x] [`webtorrent-desktop`](https://github.com/webtorrent/webtorrent-desktop) (https://github.com/webtorrent/webtorrent-desktop/pull/1497)