### PR TITLE
Change rule no-unused-vars to include args option

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -147,7 +147,7 @@
     "no-unsafe-finally": "error",
     "no-unsafe-negation": "error",
     "no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }],
-    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": true }],
+    "no-unused-vars": ["error", { "vars": "all", "ignoreRestSiblings": true }],
     "no-use-before-define": ["error", { "functions": false, "classes": false, "variables": false }],
     "no-useless-call": "error",
     "no-useless-computed-key": "error",


### PR DESCRIPTION
Currently `no-unused-vars` uses the option `"args": "none"`. This proposed change removes the args option (relying on the default `after-used`).

Before the change:
```js
((one, two) => {})() // passes
```

After the change:
```js
((one, two) => { return one })() // fails

((one, two) => { return two })() // passes
```

**References:**
- [ESLint documentation for no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)
- Closes standard/standard#1228