### PR TITLE
Update globals config to use 'readonly' instead of deprecated 'false'…

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -20,9 +20,9 @@
   ],
 
   "globals": {
-    "document": false,
-    "navigator": false,
-    "window": false
+    "document": "readonly",
+    "navigator": "readonly",
+    "window": "readonly"
   },
 
   "rules": {


### PR DESCRIPTION
This PR updates eslintrc.json in keeping with the following change to ESLint:

The merged https://github.com/eslint/eslint/pull/11384 deprecates the use of `true` and `false` for globals, replacing them with `writable` and `readonly`, respectively.

[Users are told](https://eslint.org/docs/user-guide/configuring#specifying-globals): "For historical reasons, the boolean value `false` and the string value `"readable"` are equivalent to `"readonly"`. Similarly, the boolean value true and the string value `"writeable"` are equivalent to `"writable"`. However, the use of older values is deprecated."