### PR TITLE
FIX - standard won't break typedoc anymore

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -137,7 +137,7 @@
     "no-template-curly-in-string": "error",
     "no-this-before-super": "error",
     "no-throw-literal": "error",
-    "no-trailing-spaces": "error",
+    "no-trailing-spaces": ["error", { "ignoreComments": true }],
     "no-undef": "error",
     "no-undef-init": "error",
     "no-unexpected-multiline": "error",


### PR DESCRIPTION
no-trailing-spaces in comment breaks TypeDoc.
Standard has fantastic standard for "coding style" but I not think it should mess with "comment style", especially when it interfere with a great tool such as typedoc. 