### PR TITLE
Enable no-var rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -162,6 +162,7 @@
     "no-useless-escape": "error",
     "no-useless-rename": "error",
     "no-useless-return": "error",
+    "no-var": "error",
     "no-whitespace-before-property": "error",
     "no-with": "error",
     "object-curly-spacing": ["error", "always"],

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,5 @@
-var config = require('../')
-var test = require('tape')
+const config = require('../')
+const test = require('tape')
 
 test('test basic properties of config', function (t) {
   t.ok(isObject(config.parserOptions))

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -1,15 +1,15 @@
-var eslint = require('eslint')
-var test = require('tape')
+const eslint = require('eslint')
+const test = require('tape')
 
 test('load config in eslint to validate all rule syntax is correct', function (t) {
-  var CLIEngine = eslint.CLIEngine
+  const CLIEngine = eslint.CLIEngine
 
-  var cli = new CLIEngine({
+  const cli = new CLIEngine({
     useEslintrc: false,
     configFile: 'eslintrc.json'
   })
 
-  var code = 'var foo = 1\nvar bar = function () {}\nbar(foo)\n'
+  const code = 'const foo = 1\nconst bar = function () {}\nbar(foo)\n'
 
   t.equal(cli.executeOnText(code).errorCount, 0)
   t.end()


### PR DESCRIPTION
Enables the [no-var](https://eslint.org/docs/rules/no-var) ESLint rule. Closes https://github.com/standard/standard/issues/633.

Of 152 repositories, 29 already pass and 123 fail:

<details>
<summary>List of repositories</summary>

- [ ] [addressbar](https://github.com/cerebral/addressbar)
- [ ] [any-db-postgres](https://github.com/grncdr/node-any-db-postgres)
- [ ] [assert-array](https://github.com/bendrucker/assert-array)
- [ ] [assert-function](https://github.com/bendrucker/assert-function)
- [ ] [assert-observ](https://github.com/bendrucker/assert-observ)
- [ ] [assert-ok](https://github.com/bendrucker/assert-ok)
- [ ] [attach-css](https://github.com/shama/attach-css)
- [ ] [ban-sensitive-files](https://github.com/bahmutov/ban-sensitive-files)
- [ ] [base-input](https://github.com/bendrucker/base-input)
- [ ] [base64-js](https://github.com/beatgammit/base64-js)
- [ ] [bittorrent-dht](https://github.com/webtorrent/bittorrent-dht)
- [ ] [bittorrent-protocol](https://github.com/webtorrent/bittorrent-protocol)
- [ ] [bittorrent-tracker](https://github.com/webtorrent/bittorrent-tracker)
- [ ] [blacklist](https://github.com/dcousens/blacklist)
- [ ] [blob-to-buffer](https://github.com/feross/blob-to-buffer)
- [ ] [board-io](https://github.com/achingbrain/board-io)
- [ ] [browser-supports-log-styles](https://github.com/gr2m/browser-supports-log-styles)
- [ ] [bs58](https://github.com/cryptocoinjs/bs58)
- [ ] [bs58check](https://github.com/bitcoinjs/bs58check)
- [ ] [buffer](https://github.com/feross/buffer)
- [ ] [buffer-xor](https://github.com/crypto-browserify/buffer-xor)
- [ ] [builtin-status-codes](https://github.com/bendrucker/builtin-status-codes)
- [ ] [bulk-write-stream](https://github.com/mafintosh/bulk-write-stream)
- [ ] [cast-array](https://github.com/bendrucker/cast-array)
- [ ] [chrome-dgram](https://github.com/feross/chrome-dgram)
- [ ] [chrome-net](https://github.com/feross/chrome-net)
- [ ] [cli-fail](https://github.com/bendrucker/cli-fail)
- [ ] [co-mocha](https://github.com/blakeembrey/co-mocha)
- [ ] [coininfo](https://github.com/cryptocoinjs/coininfo)
- [ ] [console-log-level](https://github.com/watson/console-log-level)
- [ ] [couchdb-push](https://github.com/jo/couchdb-push)
- [ ] [curry2](https://github.com/wilmoore/curry2.js)
- [ ] [cyclist](https://github.com/mafintosh/cyclist)
- [ ] [deglob](https://github.com/flet/deglob)
- [ ] [dom-event-target](https://github.com/bendrucker/dom-event-target)
- [ ] [dot-slash](https://github.com/bendrucker/dot-slash)
- [ ] [drag-drop](https://github.com/feross/drag-drop)
- [ ] [eslint-config-semistandard](https://github.com/Flet/eslint-config-semistandard)
- [ ] [evp_bytestokey](https://github.com/crypto-browserify/EVP_BytesToKey)
- [ ] [fastfall](https://github.com/mcollina/fastfall)
- [ ] [fastseries](https://github.com/mcollina/fastseries)
- [ ] [feathers-action-types](https://github.com/ahdinosaur/feathers-action-types)
- [ ] [fs-chunk-store](https://github.com/feross/fs-chunk-store)
- [ ] [fs-find-root](https://github.com/jarofghosts/fs-find-root)
- [ ] [gameloop](https://github.com/sethvincent/gameloop)
- [ ] [geohub](https://github.com/koopjs/geohub)
- [ ] [git-head](https://github.com/christophwitzko/git-head)
- [ ] [gl-blend-demo](https://github.com/Jam3/gl-blend-demo)
- [ ] [gl-cubemap-placeholder](https://github.com/wwwtyro/gl-cubemap-placeholder)
- [ ] [hapi-cors-headers](https://github.com/gr2m/hapi-cors-headers)
- [ ] [har-validator](https://github.com/ahmadnassri/har-validator)
- [ ] [has-require](https://github.com/bendrucker/has-require)
- [ ] [hash-index](https://github.com/watson/hash-index)
- [ ] [html-pdf](https://github.com/marcbachmann/node-html-pdf)
- [ ] [ieee754](https://github.com/feross/ieee754)
- [ ] [inject-lr-script](https://github.com/mattdesl/inject-lr-script)
- [ ] [instant.io](https://github.com/webtorrent/instant.io)
- [ ] [int-encoder](https://github.com/alanclarke/int-encoder)
- [ ] [is-ci](https://github.com/watson/is-ci)
- [ ] [is-electron-renderer](https://github.com/jprichardson/is-electron-renderer)
- [ ] [is-generator](https://github.com/blakeembrey/is-generator)
- [ ] [is-package](https://github.com/bendrucker/is-package)
- [ ] [memory-chunk-store](https://github.com/mafintosh/memory-chunk-store)
- [ ] [merkledag-store](https://github.com/diasdavid/js-merkledag-store)
- [ ] [metalsmith-register-helpers](https://github.com/losttype/metalsmith-register-helpers)
- [ ] [mightyiam](https://github.com/mightyiam/mightyiam.js)
- [ ] [mqemitter](https://github.com/mcollina/mqemitter)
- [ ] [multihashes](https://github.com/jbenet/js-multihash)
- [ ] [multihashing](https://github.com/jbenet/js-multihashing)
- [ ] [multistream](https://github.com/feross/multistream)
- [ ] [numeric-id-map](https://github.com/mafintosh/numeric-id-map)
- [ ] [object-pair](https://github.com/bendrucker/object-pair)
- [ ] [observ-value](https://github.com/bendrucker/observ-value)
- [ ] [osprey-router](https://github.com/mulesoft-labs/osprey-router)
- [ ] [parse-int](https://github.com/bendrucker/parse-int)
- [ ] [parse-torrent](https://github.com/webtorrent/parse-torrent)
- [ ] [patch-text](https://github.com/bendrucker/patch-text)
- [ ] [path-to-regexp](https://github.com/pillarjs/path-to-regexp)
- [ ] [popsicle-server](https://github.com/blakeembrey/popsicle-server)
- [ ] [postgres-array](https://github.com/bendrucker/postgres-array)
- [ ] [program-version](https://github.com/wilmoore/program-version)
- [ ] [random-iterate](https://github.com/mafintosh/random-iterate)
- [ ] [re-emitter](https://github.com/feross/re-emitter)
- [ ] [read-closest-package](https://github.com/mattdesl/read-closest-package)
- [ ] [require-deps](https://github.com/bendrucker/require-deps)
- [ ] [reusify](https://github.com/mcollina/reusify)
- [ ] [rocha](https://github.com/bahmutov/rocha)
- [ ] [round-precision](https://github.com/bendrucker/round-precision)
- [ ] [run-auto](https://github.com/feross/run-auto)
- [ ] [run-parallel](https://github.com/feross/run-parallel)
- [ ] [run-parallel-limit](https://github.com/feross/run-parallel-limit)
- [ ] [run-series](https://github.com/feross/run-series)
- [ ] [run-waterfall](https://github.com/feross/run-waterfall)
- [ ] [sanitycheck](https://github.com/jden/node-sanitycheck)
- [ ] [simple-bin-help](https://github.com/bahmutov/simple-bin-help)
- [ ] [simple-format](https://github.com/bendrucker/simple-format)
- [ ] [simple-get](https://github.com/feross/simple-get)
- [ ] [simple-peer](https://github.com/feross/simple-peer)
- [ ] [simple-websocket](https://github.com/feross/simple-websocket)
- [ ] [snazzy](https://github.com/standard/snazzy)
- [ ] [socketio-wildcard](https://github.com/hden/socketio-wildcard)
- [ ] [sodium-signatures](https://github.com/mafintosh/sodium-signatures)
- [ ] [spawn-npm-install](https://github.com/mattdesl/spawn-npm-install)
- [ ] [split2](https://github.com/mcollina/split2)
- [ ] [standard-engine](https://github.com/flet/standard-engine)
- [ ] [standard-format](https://github.com/maxogden/standard-format)
- [ ] [standard-json](https://github.com/flet/standard-json)
- [ ] [standard-packages](https://github.com/standard/standard-packages)
- [ ] [standard-www](https://github.com/standard/standard-www)
- [ ] [stream-to-blob-url](https://github.com/feross/stream-to-blob-url)
- [ ] [studynotes.org](https://github.com/feross/studynotes.org)
- [ ] [supertest-koa-agent](https://github.com/wilmoore/node-supertest-koa-agent)
- [ ] [tape-promise](https://github.com/jprichardson/tape-promise)
- [ ] [typedarray-to-buffer](https://github.com/feross/typedarray-to-buffer)
- [ ] [unique-filename](https://github.com/iarna/unique-filename)
- [ ] [url-mapper](https://github.com/cerebral/url-mapper)
- [ ] [value-pipe](https://github.com/bendrucker/value-pipe)
- [ ] [view-list](https://github.com/shama/view-list)
- [ ] [view-size](https://github.com/bendrucker/view-size)
- [ ] [weakmap-event](https://github.com/eaze/weakmap-event)
- [x] [webtorrent](https://github.com/webtorrent/webtorrent)
- [x] [webtorrent.io](https://github.com/webtorrent/webtorrent.io)
- [ ] [wifi-triangulate](https://github.com/watson/wifi-triangulate)
- [x] [acho](https://github.com/kikobeats/acho)
- [x] [babel-tape-runner](https://github.com/wavded/babel-tape-runner)
- [x] [bitmidi.com](https://github.com/feross/bitmidi.com)
- [x] [create-torrent](https://github.com/webtorrent/create-torrent)
- [x] [dom-stub](https://github.com/npm-dom/dom-stub)
- [x] [draw-to-canvas](https://github.com/willhoag/draw-to-canvas)
- [x] [echint](https://github.com/ahmadnassri/echint)
- [x] [fs-writefile-promise](https://github.com/ahmadnassri/fs-writefile-promise)
- [x] [gulp-codecov.io](https://github.com/eddiemoore/gulp-codecov.io)
- [x] [icss-replace-symbols](https://github.com/css-modules/icss-replace-symbols)
- [x] [immediate-chunk-store](https://github.com/feross/immediate-chunk-store)
- [x] [is-installed](https://github.com/tunnckoCore/is-installed)
- [x] [is-server-response](https://github.com/yoshuawuyts/is-server-response)
- [x] [karma-cli](https://github.com/karma-runner/karma-cli)
- [x] [koop](https://github.com/koopjs/koop)
- [x] [libp2p-tcp](https://github.com/diasdavid/js-libp2p-tcp)
- [x] [magnet-uri](https://github.com/webtorrent/magnet-uri)
- [x] [mkdirp-promise](https://github.com/ahmadnassri/mkdirp-promise)
- [x] [postcss-modules-values](https://github.com/css-modules/postcss-modules-constants)
- [x] [publish-dist](https://github.com/tlvince/publish-dist)
- [x] [redbox-react](https://github.com/KeywordBrain/redbox-react)
- [x] [reeal](https://github.com/reg4in/reeal)
- [x] [tap](https://github.com/tapjs/node-tap)
- [x] [torrent-discovery](https://github.com/webtorrent/torrent-discovery)
- [x] [torrent-piece](https://github.com/webtorrent/torrent-piece)
- [x] [ut_metadata](https://github.com/webtorrent/ut_metadata)
- [x] [webtorrent-desktop](https://github.com/webtorrent/webtorrent-desktop)
- [x] [xo-collection](https://github.com/marsaud/collection)
- [x] [xo-lib](https://github.com/vatesfr/xo-lib)
</details>