### PR TITLE
Fix es2020 globals not being recognized

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -8,7 +8,7 @@
   },
 
   "env": {
-    "es6": true,
+    "es2020": true,
     "node": true
   },
 


### PR DESCRIPTION
Fixes standard/standard#1436

The ecmaVersion in parserOptions is only for setting syntax support.

From the docs: https://eslint.org/docs/user-guide/configuring

> supporting ES6 syntax is not the same as supporting new ES6 globals

Setting the es2020 env will actually set the globals:

> adds all ECMAScript 2020 globals and automatically sets the ecmaVersion parser option to 11.

<!--
  Proposing a new rule or a rule change? Please open an issue here first:
  https://github.com/standard/standard/issues
  
  If the rule has been accepted and you want to send a PR, please send it
  to: https://github.com/standard/standard. Add the rule to the
  'eslintrc.json' file, in the "rules" field. This is where rules live
  until a new major version of standard is released, at which point all
  new rules and rule changes are moved into eslint-config-standard.
-->
