### PR TITLE
Add object-shorthand rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -169,6 +169,7 @@
     "object-curly-newline": ["error", { "multiline": true, "consistent": true }],
     "object-curly-spacing": ["error", "always"],
     "object-property-newline": ["error", { "allowMultiplePropertiesPerLine": true }],
+    "object-shorthand": ["error", "properties"],
     "one-var": ["error", { "initialized": "never" }],
     "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before", "|>": "before" } }],
     "padded-blocks": ["error", { "blocks": "never", "switches": "never", "classes": "never" }],


### PR DESCRIPTION
Eco-system breakage:

- [ ] [`semistandard`](https://github.com/standard/semistandard)
- [ ] [`tar-stream`](https://github.com/mafintosh/tar-stream)
- [ ] [`david`](https://github.com/alanshaw/david)
- [ ] [`subleveldown`](https://github.com/Level/subleveldown)
- [ ] [`simple-peer`](https://github.com/feross/simple-peer)
- [ ] [`bs58check`](https://github.com/bitcoinjs/bs58check)
- [ ] [`standard-format`](https://github.com/maxogden/standard-format)
- [ ] [`multiaddr`](https://github.com/multiformats/js-multiaddr)
- [ ] [`standard-engine`](https://github.com/standard/standard-engine)
- [ ] [`multihashing`](https://github.com/multiformats/js-multihashing)
- [ ] [`humanize-duration`](https://github.com/EvanHahn/HumanizeDuration.js)
- [ ] [`markdown-pdf`](https://github.com/alanshaw/markdown-pdf)
- [ ] [`fastparallel`](https://github.com/mcollina/fastparallel)
- [ ] [`bittorrent-dht`](https://github.com/webtorrent/bittorrent-dht)
- [ ] [`simple-bin-help`](https://github.com/bahmutov/simple-bin-help)
- [ ] [`bittorrent-tracker`](https://github.com/webtorrent/bittorrent-tracker)
- [ ] [`rocha`](https://github.com/bahmutov/rocha)
- [ ] [`multihashes`](https://github.com/multiformats/js-multihash)
- [ ] [`mqemitter`](https://github.com/mcollina/mqemitter)
- [ ] [`reusify`](https://github.com/mcollina/reusify)
- [ ] [`weakmap-event`](https://github.com/bendrucker/weakmap-event)
- [ ] [`subcommand`](https://github.com/maxogden/subcommand)
- [ ] [`chrome-net`](https://github.com/feross/chrome-net)
- [ ] [`ipld`](https://github.com/ipld/js-ipld-dag-cbor)
- [ ] [`fs-chunk-store`](https://github.com/feross/fs-chunk-store)
- [ ] [`coininfo`](https://github.com/cryptocoinjs/coininfo)
- [ ] [`aerospike`](https://github.com/aerospike/aerospike-client-nodejs)
- [ ] [`ban-sensitive-files`](https://github.com/bahmutov/ban-sensitive-files)
- [ ] [`simple-websocket`](https://github.com/feross/simple-websocket)
- [ ] [`chrome-dgram`](https://github.com/feross/chrome-dgram)
- [ ] [`base-input`](https://github.com/bendrucker/base-input)
- [ ] [`bip38`](https://github.com/bitcoinjs/bip38)
- [ ] [`sodium-signatures`](https://github.com/mafintosh/sodium-signatures)
- [ ] [`glslify-bundle`](https://github.com/glslify/glslify-bundle)
- [ ] [`aedes-persistence`](https://github.com/mcollina/aedes-persistence)
- [ ] [`int-encoder`](https://github.com/alanclarke/int-encoder)
- [ ] [`osprey-router`](https://github.com/mulesoft-labs/osprey-router)
- [ ] [`geohub`](https://github.com/koopjs/geohub)
- [ ] [`evp_bytestokey`](https://github.com/crypto-browserify/EVP_BytesToKey)
- [ ] [`url-mapper`](https://github.com/cerebral/url-mapper)
- [ ] [`gl-blend-demo`](https://github.com/Jam3/gl-blend-demo)
- [ ] [`tape-promise`](https://github.com/jprichardson/tape-promise)
- [ ] [`stackman`](https://github.com/watson/stackman)
- [ ] [`instant.io`](https://github.com/webtorrent/instant.io)
- [ ] [`webtorrent.io`](https://github.com/webtorrent/webtorrent.io)
- [ ] [`karma-chrome-launcher`](https://github.com/karma-runner/karma-chrome-launcher)
- [ ] [`eslint-plugin-standard`](https://github.com/standard/eslint-plugin-standard)
- [ ] [`studynotes.org`](https://github.com/feross/studynotes.org)
- [ ] [`bitmidi.com`](https://github.com/feross/bitmidi.com)
- [ ] [`webtorrent-desktop`](https://github.com/webtorrent/webtorrent-desktop)
- [ ] [`levelup`](https://github.com/Level/levelup)
- [ ] [`front-matter`](https://github.com/jxson/front-matter)
- [ ] [`memdown`](https://github.com/Level/memdown)
- [ ] [`leveldown`](https://github.com/Level/leveldown)
- [ ] [`assets-webpack-plugin`](https://github.com/ztoben/assets-webpack-plugin)
- [ ] [`pino`](https://github.com/pinojs/pino)
- [ ] [`testdouble`](https://github.com/testdouble/testdouble.js)
- [ ] [`fastify`](https://github.com/fastify/fastify)