### PR TITLE
Update to rules moved out from ESLint 7

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -50,7 +50,6 @@
     "eqeqeq": ["error", "always", { "null": "ignore" }],
     "func-call-spacing": ["error", "never"],
     "generator-star-spacing": ["error", { "before": true, "after": true }],
-    "handle-callback-err": ["error", "^(err|error)$" ],
     "indent": ["error", 2, {
       "SwitchCase": 1,
       "VariableDeclarator": 1,
@@ -125,13 +124,11 @@
     "no-new": "error",
     "no-new-func": "error",
     "no-new-object": "error",
-    "no-new-require": "error",
     "no-new-symbol": "error",
     "no-new-wrappers": "error",
     "no-obj-calls": "error",
     "no-octal": "error",
     "no-octal-escape": "error",
-    "no-path-concat": "error",
     "no-proto": "error",
     "no-redeclare": ["error", { "builtinGlobals": false }],
     "no-regex-spaces": "error",
@@ -205,7 +202,10 @@
     "import/no-named-default": "error",
     "import/no-webpack-loader-syntax": "error",
 
+    "node/handle-callback-err": ["error", "^(err|error)$" ],
     "node/no-deprecated-api": "error",
+    "node/no-new-require": "error",
+    "node/no-path-concat": "error",
     "node/process-exit-as-throw": "error",
 
     "promise/param-names": "error",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "eslint": "^6.2.2",
     "eslint-plugin-import": "^2.18.0",
-    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",
     "tape": "^4.8.0"
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "eslint": ">=6.2.2",
     "eslint-plugin-import": ">=2.18.0",
-    "eslint-plugin-node": ">=9.1.0",
+    "eslint-plugin-node": ">=11.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0"
   },


### PR DESCRIPTION
This should (probably, right?) be a breaking change since we are changing a peer dependency.