### PR TITLE
Add new rules from ESLint 7.0.0

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -44,6 +44,7 @@
     "computed-property-spacing": ["error", "never"],
     "constructor-super": "error",
     "curly": ["error", "multi-line"],
+    "default-case-last": "error",
     "dot-location": ["error", "property"],
     "dot-notation": ["error", { "allowKeywords": true }],
     "eol-last": "error",
@@ -108,6 +109,7 @@
     "no-lone-blocks": "error",
     "no-misleading-character-class": "error",
     "no-prototype-builtins": "error",
+    "no-useless-backreference": "error",
     "no-useless-catch": "error",
     "no-mixed-operators": ["error", {
       "groups": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/standard/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^6.2.2",
+    "eslint": "^7.0.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
@@ -48,7 +48,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": ">=6.2.2",
+    "eslint": ">=7.0.0",
     "eslint-plugin-import": ">=2.18.0",
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",


### PR DESCRIPTION
This is a breaking change.

No packages in the ecosystem are impacted by the added rules.