### PR TITLE
Relax rule: allow yoda for ranges

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -196,7 +196,7 @@
     "valid-typeof": ["error", { "requireStringLiterals": true }],
     "wrap-iife": ["error", "any", { "functionPrototypeMethods": true }],
     "yield-star-spacing": ["error", "both"],
-    "yoda": ["error", "never"],
+    "yoda": ["error", "never", { "exceptRange": true }],
 
     "import/export": "error",
     "import/first": "error",


### PR DESCRIPTION
As discussed in https://github.com/standard/standard/issues/1459 it should allow writing more readable code

Sorry for not following the issue template and not creating a PR to `https://github.com/standard/standard#eslintrc.json` but from what I see from the history of that file, suggested way is obsolete since 14.0.0 release and I didn't found any other place for creating a PR but this