### PR TITLE
Disable indent in conflicting JSX indent touched code

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -64,7 +64,7 @@
       "ImportDeclaration": 1,
       "flatTernaryExpressions": false,
       "ignoreComments": false,
-      "ignoredNodes": ["TemplateLiteral *"],
+      "ignoredNodes": ["TemplateLiteral *", "JSXElement *"],
       "offsetTernaryExpressions": true
     }],
     "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],


### PR DESCRIPTION
Fixes https://github.com/standard/eslint-config-standard/issues/177

My only worry is that there is some use for indent rules inside of JSX that are intended to overlap with standard-jsx? Not sure, anyone familiar?

<!--
  Proposing a new rule or a rule change? Please open an issue here first:
  https://github.com/standard/standard/issues
  
  If the rule has been accepted and you want to send a PR, please send it
  to: https://github.com/standard/standard. Add the rule to the
  'eslintrc.json' file, in the "rules" field. This is where rules live
  until a new major version of standard is released, at which point all
  new rules and rule changes are moved into eslint-config-standard.
-->
