### PR TITLE
fix: allow eslint-plugin-promise v5 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint": "^7.12.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1"
+    "eslint-plugin-promise": "^4.2.1 || ^5.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Allow `eslint-plugin-promise` v5 as peer dependency.

Fixes the following use case https://github.com/netlify/eslint-config-node/pull/160#issuecomment-817407644 and extracted from https://github.com/standard/eslint-config-standard/pull/183 to separate concerns.