### PR TITLE
ci: change Travis to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: 'ci'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  ci:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v2'
+
+      - name: 'Use Node.js'
+        uses: 'actions/setup-node@v2.4.0'
+        with:
+          node-version: 'lts/*'
+
+      - name: 'Cache Node dependencies'
+        uses: 'actions/cache@v2.1.6'
+        with:
+          path: '~/.npm'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: 'Install dependencies'
+        run: 'npm install'
+
+      - name: 'Run tests'
+        run: 'npm test'

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-.travis.yml
 test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - lts/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# eslint-config-standard [![travis][travis-image]][travis-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]
+# eslint-config-standard [![CI][ci-image]][ci-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]
 
-[travis-image]: https://img.shields.io/travis/standard/eslint-config-standard/master.svg
-[travis-url]: https://travis-ci.org/standard/eslint-config-standard
+[ci-image]: https://github.com/standard/eslint-config-standard/actions/workflows/ci.yml/badge.svg?branch=master
+[ci-url]: https://github.com/standard/eslint-config-standard/actions/workflows/ci.yml
 [npm-image]: https://img.shields.io/npm/v/eslint-config-standard.svg
 [npm-url]: https://npmjs.org/package/eslint-config-standard
 [downloads-image]: https://img.shields.io/npm/dm/eslint-config-standard.svg


### PR DESCRIPTION
**What changes did you make? (Give an overview)**

- [x] Change travis configuration to GitHub Actions for continuous integration

This allows us to be consistent across the organization, we're slowly migrating to GitHub Actions.

Related: https://github.com/standard/eslint-config-standard-with-typescript/pull/530, https://github.com/standard/standard-engine/pull/233, https://github.com/standard/standard-engine/pull/233