### PR TITLE
feat: support eslint v8

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
 
   "plugins": [
     "import",
-    "node",
+    "n",
     "promise"
   ],
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "latest",
+    "ecmaVersion": 2021,
     "ecmaFeatures": {
       "jsx": true
     },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -230,13 +230,13 @@
     "import/no-named-default": "error",
     "import/no-webpack-loader-syntax": "error",
 
-    "node/handle-callback-err": ["error", "^(err|error)$" ],
-    "node/no-callback-literal": "error",
-    "node/no-deprecated-api": "error",
-    "node/no-exports-assign": "error",
-    "node/no-new-require": "error",
-    "node/no-path-concat": "error",
-    "node/process-exit-as-throw": "error",
+    "n/handle-callback-err": ["error", "^(err|error)$" ],
+    "n/no-callback-literal": "error",
+    "n/no-deprecated-api": "error",
+    "n/no-exports-assign": "error",
+    "n/no-new-require": "error",
+    "n/no-path-concat": "error",
+    "n/process-exit-as-throw": "error",
 
     "promise/param-names": "error"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2021,
+    "ecmaVersion": "latest",
     "ecmaFeatures": {
       "jsx": true
     },

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The above steps will automatically set up an ESLint configuration and install th
 **If you want to set up the config manually**, run the following command:
 
 ```bash
-npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node
+npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-n
 ```
 
 Then, add this to your `.eslintrc` file:

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/standard/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^8.0.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^8.0.1",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-promise": "^5.1.0",
     "tape": "^5.0.1"
   },
   "homepage": "https://github.com/standard/eslint-config-standard",
@@ -47,10 +47,10 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": "^8.0.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^8.0.1",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1 || ^5.0.0"
+    "eslint-plugin-promise": "^5.1.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "url": "https://github.com/standard/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^8.0.1",
-    "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
-    "tape": "^5.0.1"
+    "eslint": "^8.5.0",
+    "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-n": "^14.0.0",
+    "eslint-plugin-promise": "^6.0.0",
+    "tape": "^5.3.2"
   },
   "homepage": "https://github.com/standard/eslint-config-standard",
   "keywords": [
@@ -49,8 +49,8 @@
   "peerDependencies": {
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0"
+    "eslint-plugin-n": "^14.0.0",
+    "eslint-plugin-promise": "^6.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/standard/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^7.12.1",
+    "eslint": "^8.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
@@ -47,7 +47,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": "^7.12.1",
+    "eslint": "^8.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1 || ^5.0.0"


### PR DESCRIPTION
<!--
  Proposing a new rule or a rule change? Please open an issue here first:
  https://github.com/standard/standard/issues
  
  If the rule has been accepted and you want to send a PR, please send it
  to: https://github.com/standard/standard. Add the rule to the
  'eslintrc.json' file, in the "rules" field. This is where rules live
  until a new major version of standard is released, at which point all
  new rules and rule changes are moved into eslint-config-standard.
-->

ESLint v8 has been released stable. :tada:
It's time to support `eslint@8`.

See: https://eslint.org/blog/2021/10/eslint-v8.0.0-released

Blocked by:
- [x] https://github.com/import-js/eslint-plugin-import/issues/2211
- [x] https://github.com/mysticatea/eslint-plugin-node/pull/295 (replaced by  https://www.npmjs.com/package/eslint-plugin-n)
- [x] https://github.com/xjamundx/eslint-plugin-promise/issues/218

Closes #192
