### PR TITLE
ci: unpin core actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: 'actions/checkout@v2'
 
       - name: 'Use Node.js'
-        uses: 'actions/setup-node@v2.4.0'
+        uses: 'actions/setup-node@v2'
         with:
           node-version: 'lts/*'
 
       - name: 'Cache Node dependencies'
-        uses: 'actions/cache@v2.1.6'
+        uses: 'actions/cache@v2'
         with:
           path: '~/.npm'
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
<!--
  Proposing a new rule or a rule change? Please open an issue here first:
  https://github.com/standard/standard/issues
  
  If the rule has been accepted and you want to send a PR, please send it
  to: https://github.com/standard/standard. Add the rule to the
  'eslintrc.json' file, in the "rules" field. This is where rules live
  until a new major version of standard is released, at which point all
  new rules and rule changes are moved into eslint-config-standard.
-->
The core actions use floating tags for the major release lines to keep up the latest changes