### PR TITLE
Fix typo in yarn install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The above steps will automatically set up an ESLint configuration and install th
 **If you want to set up the config manually**, run the following command:
 
 ```bash
-npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-n
+npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node
 ```
 
 Then, add this to your `.eslintrc` file:


### PR DESCRIPTION
Currently it says that you need `eslint-plugin-n` instead of `eslint-plugin-node`