### PR TITLE
fix: allow top-level `await` support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2021,
+    "ecmaVersion": 2022,
     "ecmaFeatures": {
       "jsx": true
     },

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "url": "https://github.com/standard/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^8.6.0",
+    "@types/eslint": "^8.4.1",
+    "@types/tape": "^4.13.2",
+    "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-n": "^14.0.0",
     "eslint-plugin-promise": "^6.0.0",
-    "tape": "^5.4.0"
+    "tape": "^5.5.0"
   },
   "homepage": "https://github.com/standard/eslint-config-standard",
   "keywords": [

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -8,3 +8,11 @@ test('load config in eslint to validate all rule syntax is correct', async funct
   t.equal(lintResult.errorCount, 0)
   t.end()
 })
+
+test('ensure we allow top level await', async function (t) {
+  const eslint = new ESLint()
+  const code = 'const foo = await 1\nconst bar = function () {}\nawait bar(foo)\n'
+  const [lintResult] = await eslint.lintText(code)
+  t.equal(lintResult.errorCount, 0)
+  t.end()
+})


### PR DESCRIPTION
Turns out we should have set the `parserOptions`to `2022` rather than `2021`.

This PR fixes that + adds a test for it 👍 

Fixes https://github.com/standard/standard/issues/1548