### PR TITLE
Add missing 'ode' to eslint-plugin-node in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The above steps will automatically set up an ESLint configuration and install th
 **If you want to set up the config manually**, run the following command:
 
 ```bash
-npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-n
+npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node
 ```
 
 Then, add this to your `.eslintrc` file:


### PR DESCRIPTION
You remove some chars that I think you shouldn't do next time ;)