### PR TITLE
Support latest `eslint-plugin-n`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/tape": "^4.13.2",
     "eslint": "^8.13.0",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-n": "^15.1.0",
+    "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "tape": "^5.5.2"
   },
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-n": "^15.0.0",
+    "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
     "eslint-plugin-promise": "^6.0.0"
   },
   "repository": {


### PR DESCRIPTION
A new major version, 16.x, of `eslint-plugin-n` was released. This adds support for that one without breaking support with 15.x