### PR TITLE
Allow for 16.6 or greater OR 17.9 (latest) or greater eslint-plugin-n

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "globals": "13.24.0",
     "eslint-plugin-import": "2.29.1",
-    "eslint-plugin-n": "16.6.2",
+    "eslint-plugin-n": "^16 >=16.6 || >=17.9",
     "eslint-plugin-promise": "6.2.0"
   }
 }


### PR DESCRIPTION
The eslint-plugin-n package has had a major version bump (https://github.com/eslint-community/eslint-plugin-n/blob/master/CHANGELOG.md#1700-2024-04-08).

The breaking changes don't seem to affect this library and it's preventing some users of this library from upgrading their eslint-plugin-n dep.
