### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/standard/eslint-config-standard.git"
+    "url": "git+https://github.com/standard/eslint-config-standard.git"
   },
   "scripts": {
     "clean-artifacts": "git clean lib -X --force",


### PR DESCRIPTION
## Summary
- update the package repository URL from `git://` to `git+https://`
- leave runtime code, dependencies, package version, entry points, types, homepage, bugs metadata, license, and package contents unchanged

## Validation
- `npm view eslint-config-standard --json`
- metadata assertion for package identity, entry points, types, homepage, bugs, license, and repository fields
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`